### PR TITLE
Make configuration easier by including user_config.h

### DIFF
--- a/pwm.c
+++ b/pwm.c
@@ -26,8 +26,12 @@
 #ifndef PWM_MAX_CHANNELS
   #define PWM_MAX_CHANNELS 8
 #endif
-#define PWM_DEBUG 0
-#define PWM_USE_NMI 0
+#ifndef PWM_DEBUG
+  #define PWM_DEBUG 0
+#endif
+#ifndef PWM_USE_NMI
+  #define PWM_USE_NMI 0
+#endif
 
 /* no user servicable parts beyond this point */
 

--- a/pwm.c
+++ b/pwm.c
@@ -18,6 +18,8 @@
 
 /* Set the following three defines to your needs */
 
+#include "user_config.h"
+
 #ifndef SDK_PWM_PERIOD_COMPAT_MODE
   #define SDK_PWM_PERIOD_COMPAT_MODE 0
 #endif


### PR DESCRIPTION
By including `user_config.h` at the top of the file, it's possible to make configuration changes while using the unmodified code from the repository.

To make that also possible for both PWM_DEBUG and PWM_USE_NMI, include them in ifndef like already done for SDK_PWM_PERIOD_COMPAT_MODE and PWM_MAX_CHANNELS.