### PR TITLE
Fix conversion when COMPAT_MODE is set

### DIFF
--- a/pwm.c
+++ b/pwm.c
@@ -31,10 +31,10 @@
 
 #define PWM_MAX_TICKS 0x7fffff
 #if SDK_PWM_PERIOD_COMPAT_MODE
-#define PWM_PERIOD_TO_TICKS(x) (x * 0.2)
-#define PWM_DUTY_TO_TICKS(x) (x * 5)
-#define PWM_MAX_DUTY (PWM_MAX_TICKS * 0.2)
-#define PWM_MAX_PERIOD (PWM_MAX_TICKS * 5)
+#define PWM_PERIOD_TO_TICKS(x) (x * 5)
+#define PWM_DUTY_TO_TICKS(x) (x * 0.2)
+#define PWM_MAX_DUTY (PWM_MAX_TICKS * 5)
+#define PWM_MAX_PERIOD (PWM_MAX_TICKS * 0.2)
 #else
 #define PWM_PERIOD_TO_TICKS(x) (x)
 #define PWM_DUTY_TO_TICKS(x) (x)


### PR DESCRIPTION
The conversion was just backwards. In COMPAT_MODE, period value of 1000
corresponds to 1kHz, while, without COMPAT_MODE, 5000 corresponds to
the same period. So when SDK_PWM_PERIOD_COMPAT_MODE is set, period
should be multiplied by 5. For the same reason, duty needs to be
divided by 5.