### PR TITLE
Clean up example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,34 @@ above.
 
 Example usage:
 
+	#include "pwm.h"
+
 	#define PWM_CHANNELS 5
 	const uint32_t period = 5000; // * 200ns ^= 1 kHz
 
 	// PWM setup
 	uint32 io_info[PWM_CHANNELS][3] = {
 		// MUX, FUNC, PIN
+		{PERIPHS_IO_MUX_GPIO4_U, FUNC_GPIO4,   4},
+		{PERIPHS_IO_MUX_GPIO5_U, FUNC_GPIO5,   5},
 		{PERIPHS_IO_MUX_MTDI_U,  FUNC_GPIO12, 12},
-		{PERIPHS_IO_MUX_MTDO_U,  FUNC_GPIO15, 15},
 		{PERIPHS_IO_MUX_MTCK_U,  FUNC_GPIO13, 13},
 		{PERIPHS_IO_MUX_MTMS_U,  FUNC_GPIO14, 14},
-		{PERIPHS_IO_MUX_GPIO5_U, FUNC_GPIO5 ,  5},
 	};
 
 	// initial duty: all off
 	uint32 pwm_duty_init[PWM_CHANNELS] = {0, 0, 0, 0, 0};
 
-	pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
-	pwm_start();
+	void setup() {
+		pwm_init(period, pwm_duty_init, PWM_CHANNELS, io_info);
+	}
 
-	// do something like this whenever you want to change duty
-	pwm_set_duty(500, 1);  // GPIO15: 10%
-	pwm_set_duty(5000, 1); // GPIO15: 100%
-	pwm_start();           // commit
+	void loop() {
+		// do something like this whenever you want to change duty
+		pwm_set_duty(500, 1);  // GPIO5: 10%
+		pwm_set_duty(5000, 1); // GPIO5: 100%
+		pwm_start();           // commit
+	}
 
 **CAVEATS**
 


### PR DESCRIPTION
* Include header file
* Add `GPIO4` (safe), Remove `GPIO15` (unsafe)
(according to [this source](https://community.blynk.cc/t/esp8266-gpio-pins-info-restrictions-and-features-8/22872))
* Remove redundant `pwm_start` call (see `pwm_init`)
* Split into global, `setup` and `loop`